### PR TITLE
readlink on OS X is not the same as readlink on Linux :-(

### DIFF
--- a/zsh-completion-generator.plugin.zsh
+++ b/zsh-completion-generator.plugin.zsh
@@ -6,7 +6,7 @@
 # http://github.com/RobSis/zsh-completion-generator
 
 if [[ "$(uname -s)" = "Darwin" ]]; then
-    SCRIPT_SOURCE=$(dirname ${0})
+    SCRIPT_SOURCE=$(builtin cd "$(dirname "$(readlink "$0" || echo "$0")")"; pwd)
 else
     SCRIPT_SOURCE=$(/bin/readlink -f ${0%/*})
 fi


### PR DESCRIPTION
I was getting errors loading the plugin because OS X's readlink isn't at all like readlink on Linux. Yet another case of getting burned by the BSD / GNU userland differences
