### PR TITLE
Ignore completions folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Generated completions
+completions


### PR DESCRIPTION
No need to have them tracked in git, and for those of that use submodules/subtrees, it causes the main git repo to have uncommitted changes.