### PR TITLE
follow zsh conventions of two space indents and lowercase

### DIFF
--- a/help2comp.py
+++ b/help2comp.py
@@ -26,14 +26,14 @@ local arguments
 
 arguments=(
 $argument_list
-    '*:filename:_files'
+  '*:filename:_files'
 )
 
 _arguments -s $arguments
 """
 
-ARGUMENT_TEMPLATE = """    {$opts}'[$description]$style'"""
-SINGLE_ARGUMENT_TEMPLATE = """    '$opt[$description]$style'"""
+ARGUMENT_TEMPLATE = """  {$opts}'[$description]$style'"""
+SINGLE_ARGUMENT_TEMPLATE = """  '$opt[$description]$style'"""
 
 
 def cut_option(line):
@@ -101,7 +101,10 @@ def generate_argument_list(options):
         model = {}
         # remove unescapable chars.
 
-        model['description'] = _escape(opts[-1])
+	desc = list(_escape(opts[-1]))
+	if len(desc) > 1 and desc[1].islower():
+	    desc[0] = desc[0].lower()
+        model['description'] = "".join(desc)
         model['style'] = ""
         if (len(opts) > 2):
             model['opts'] = ",".join(opts[:-1])


### PR DESCRIPTION
As the generated function can be used as the basis of a function that is improved and then contributed to zsh, it would be nice if it followed the zsh conventions. In particular two spaces for indentation and lowercase descriptions.

Other things that could be improved include:
  Adding exclusion lists, e.g. for cat, '(-A --show-all)'{-A,--show-all}'[equivalent to -vET]'
  For --help, --version etc options, '(- _)' is usually applicable.
  For --verbose and --quiet, multiple repeats are often allows so: \_{-v,--verbose}...
  Handle single quotes in descriptions. Switching to double quotes works in most cases. 

Note that zsh's _arguments has builtin functionality similar to zsh-completion-generator but it generates the internal structures rather than a usable function.
