### PR TITLE
An uplift iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ into your `.zshrc`.
 #### Custom zsh completion folder
 If you want to use a different folder than the default one for completion files, you can export the GENCOMPL_FPATH variable before sourcing the plugin :
 
-    $ GENCOMPL_FPATH = $HOME/.zsh/complete
+    $ GENCOMPL_FPATH=$HOME/.zsh/complete
     $ source $HOME/.zsh/zsh-completion-generator/zsh-completion-generator.plugin.zsh
 
 
@@ -48,20 +48,26 @@ If you want to use a different folder than the default one for completion files,
 #### Custom python version
 If you ant to use a specific python interpreter name, you can export the GENCOMPL_PY variable before sourcing the plugin :
 
-    $ GENCOMPL_PY = python2
+    $ GENCOMPL_PY=python2
     $ source $HOME/.zsh/zsh-completion-generator/zsh-completion-generator.plugin.zsh
 
 Please note that currently python 3 is not supported.
 
 How to use
 ----------
-You must edit the plugin to change the list of programs, or you can
-generate them from the shell:
+Provide default program list by (example):
 
-    $ gencomp nl
-    $ source ~/.zshrc
-    $ nl -*[TAB]* -> magic
+```zsh
+zstyle :plugin:zsh-completion-generator programs   ggrep tr cat
+```
 
+The plugin will create completions for those programs at load time, once.
+You can also generate completions from the shell, by using provided `gencomp`
+function:
+
+    $ gencomp ggrep
+    $ source ~/.zshrc # or run `compinit'
+    $ ggrep -*[TAB]* -> magic
 
 Licence
 -------

--- a/zsh-completion-generator.plugin.zsh
+++ b/zsh-completion-generator.plugin.zsh
@@ -5,61 +5,82 @@
 # and generate zsh(1) completion functions.
 # http://github.com/RobSis/zsh-completion-generator
 
-ZSH_COMPLETION_GENERATOR_SRCDIR=${0:A:h}
+# Fetch $0 according to plugin standard proposed at:
+# http://zdharma.org/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
+ZERO="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+ZSH_COMPLETION_GENERATOR_SRCDIR=${ZERO:A:h}
+
 if [ -z $GENCOMPL_FPATH ]; then
     ZSH_COMPLETION_GENERATOR_DIR="$ZSH_COMPLETION_GENERATOR_SRCDIR/completions"
 else
     ZSH_COMPLETION_GENERATOR_DIR="$GENCOMPL_FPATH"
 fi
-# don't overwrite existing functions
-fpath=($fpath $ZSH_COMPLETION_GENERATOR_DIR)
+# don't override existing functions - append
+[[ -z "${fpath[(r)$ZSH_COMPLETION_GENERATOR_DIR]}" ]] && fpath=($fpath $ZSH_COMPLETION_GENERATOR_DIR)
 
 # which python to use
 local python
-if [ -z $GENCOMPL_PY ]; then
+if [[ -z $GENCOMPL_PY ]]; then
     python=python
 else
     python=$GENCOMPL_PY
 fi
-mkdir -p $ZSH_COMPLETION_GENERATOR_DIR
+[[ ! -d $ZSH_COMPLETION_GENERATOR_DIR ]] && command mkdir -p $ZSH_COMPLETION_GENERATOR_DIR
 
-# define default programs here:
-local programs
-programs=( "cat" "nl" "tr" "df --help" )
+# a) define default programs here (or provide the below zstyle in zshrc):
+local -a programs
+# -a denotes there's array in the Zstyle
+zstyle -a :plugin:zsh-completion-generator programs programs
+(( ${#programs} )) || programs=( "ggrep" "groff -h" "nl" )
 
-local prg
+# anonymous function, to have private variable scope
+() {
+local prg name help code
+local -a i
 for prg in "${programs[@]}"; do
-    local name=$prg
-    local help=--help
-    if [[ $prg =~ " " ]]; then
-        local i
-        i=( "${(s/ /)prg}" )
+    name=$prg
+    help=--help
+    # Use "% *" trick to skip using regex
+    if [[ ${prg% *} != $prg ]]; then
+        i=( "${(@s/ /)prg}" )
         name=$i[1]
-        if [ -n "$i[2]" ]; then
+        if [[ -n "$i[2]" ]]; then
             help="$i[2]"
         fi
     fi
 
     test -f $ZSH_COMPLETION_GENERATOR_DIR/_$name ||\
-        $name $help 2>&1 | $python $ZSH_COMPLETION_GENERATOR_SRCDIR/help2comp.py $name >\
-            $ZSH_COMPLETION_GENERATOR_DIR/_$name || rm -f $ZSH_COMPLETION_GENERATOR_DIR/_$name
+        $name $help 2>&1 | $python $ZSH_COMPLETION_GENERATOR_SRCDIR/help2comp.py $name >!\
+            $ZSH_COMPLETION_GENERATOR_DIR/_$name || {
+                    code="${pipestatus[1]}"
+                    command rm -f $ZSH_COMPLETION_GENERATOR_DIR/_$name
+                    # Store error message into "err_$name", once
+                    [[ ! -f $ZSH_COMPLETION_GENERATOR_DIR/err_$name ]] &&\
+                        echo "No options found for $name. Was fetching from following invocation:" \
+                             "\`$name $help'.\nProgram reacted with exit code: $code." >!\
+                                    $ZSH_COMPLETION_GENERATOR_DIR/err_$name
+                }
 done
+}
 
-# or use function in shell:
+# b) or use function in shell:
 gencomp() {
-    if [ -z "$1" ]; then
+    if [[ -z "$1" || "$1" = "-h" || "$1" = "--help" ]]; then
         echo "Usage: gencomp program [--argument-for-help-text]"
         echo
         return 1
     fi
 
     local help=--help
-    if [ -n "$2" ]; then
+    if [[ -n "$2" ]]; then
         help=$2
     fi
 
-    $1 $help 2>&1 | $python $ZSH_COMPLETION_GENERATOR_SRCDIR/help2comp.py $1 >\
-        $ZSH_COMPLETION_GENERATOR_DIR/_$1 || ( rm -f $ZSH_COMPLETION_GENERATOR_DIR/_$1 &&\
-            echo "No options found for '$1'." )
+    "$1" $help 2>&1 | $python $ZSH_COMPLETION_GENERATOR_SRCDIR/help2comp.py $1 >!\
+        $ZSH_COMPLETION_GENERATOR_DIR/_$1 || ( local code="${pipestatus[1]}"
+                command rm -f $ZSH_COMPLETION_GENERATOR_DIR/_$1 &&\
+                echo "No options found for '$1'. Was fetching from following invocation: \`$1 $help'."\
+                    "\nThe program reacted with exit code: $code."
+            )
 }
 # date +%H:%M:%S.%N   # profiling info


### PR DESCRIPTION
I liked the project and had some spare hour so I've did an uplift iteration on Zsh-part of it. The changes:

   1. Array-zstyle used to provide program list.
   2. `$0` fetched according to proposed [Zsh plugin standard](http://zdharma.org/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html).
   3. `$fpath` is extended if needed (to support multiple loads of plugin).
   4. Default list of programs: `ggrep` (works), `groff -h` (alternate help
      option, works), `nl` (doesn't work on OSX/BSD).
   5. On error, a file e.g. "err_ggrep" is created and contains error
      message and the program exit code.
   6. In-shell generation (`gencomp`) also outputs program's exit code on
      error (Zsh var `$pipestatus` is being used).
   7. `"${(s/ /)prg}"` changed to `"${(@s/ /prg}"` – @ will trigger splitting
      guaranteeing the output is an array.
   8. `gencomp` accepts -h and --help.
   9. "[ ... ]" conditions changed to [[ ... ]], this reserved-word syntax is faster
      than previous builtin-command syntax (comparison: https://www.zsh.org/mla/users/2016/msg00783.html).
   10. Anonymous function used for script body, to allow sourcing multiple
       times without messages from redefined variables.

I hope you like those changes. I've only looked at python script, who knows maybe I'll have time for it as I plan making a few completions, but I doubt it. I like the idea of the plugin though, would be great to develop it and increase complexity to handle more inputs, e.g. `cmake` in general works but it uses equal-sign `=` in the options and this is little disturbing.