### PR TITLE
plugin.zsh: Don't set ZERO param, use 0 instead, to not pass ZERO down

### DIFF
--- a/zsh-completion-generator.plugin.zsh
+++ b/zsh-completion-generator.plugin.zsh
@@ -7,8 +7,8 @@
 
 # Fetch $0 according to plugin standard proposed at:
 # http://zdharma.org/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
-ZERO="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
-ZSH_COMPLETION_GENERATOR_SRCDIR=${ZERO:A:h}
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+ZSH_COMPLETION_GENERATOR_SRCDIR=${0:A:h}
 
 if [ -z $GENCOMPL_FPATH ]; then
     ZSH_COMPLETION_GENERATOR_DIR="$ZSH_COMPLETION_GENERATOR_SRCDIR/completions"


### PR DESCRIPTION
Hello,
I've received one user report for my plugin, it revealed what I already knew, that plugins shouldn't assign `ZERO` themselves. That's the topic of the plugin standard that I create. It is already updated to not assign `ZERO` (but `0` instead).

Assigning `ZERO` is risky because the value can cascade down to next plugin. The pull request fixes this and assigns `0` not `ZERO`, and everything is fine this way.
