### PR TITLE
fix: support OSes with only python3 binary

### DIFF
--- a/zsh-completion-generator.plugin.zsh
+++ b/zsh-completion-generator.plugin.zsh
@@ -21,7 +21,11 @@ fi
 # which python to use
 local python
 if [[ -z $GENCOMPL_PY ]]; then
-    python=python
+    if [[ -z "${commands[python]}" ]] && [[ -n "${commands[python3]}" ]]; then
+        python=python3
+    else
+        python=python
+    fi
 else
     python=$GENCOMPL_PY
 fi


### PR DESCRIPTION
macOS 12.3 now only has a python3 executable; python (was python 2.x) is gone.