### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ How to install
 After installing antigen put `antigen bundle RobSis/zsh-completion-generator`
 into your `.zshrc`.
 
+### Using Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zsh-completion-generator` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-completion-generator_RobSis" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Manually
 * Download the script or clone this repository:
 


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`zsh-completion-generator` is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!
